### PR TITLE
point to the latest version of the facebook graph api

### DIFF
--- a/app/controllers/facebook_feed_controller.rb
+++ b/app/controllers/facebook_feed_controller.rb
@@ -9,7 +9,7 @@ class FacebookFeedController < ApplicationController
 
     fields = ["id", "from", "message", "picture", "link", "type", "created_time", "updated_time"]
 
-    facebook_feed_uri = URI.encode("https://graph.facebook.com/#{page_id}/posts?access_token=#{ENV['FACEBOOK_APP_ID']}|#{ENV['FACEBOOK_APP_SECRET']}&fields=#{fields.join(',')}")
+    facebook_feed_uri = URI.encode("https://graph.facebook.com/v2.6/#{page_id}/posts?access_token=#{ENV['FACEBOOK_APP_ID']}|#{ENV['FACEBOOK_APP_SECRET']}&fields=#{fields.join(',')}")
     response = HTTParty.get(facebook_feed_uri)
 
     render json: response.parsed_response

--- a/spec/controllers/facebook_feed_controller_spec.rb
+++ b/spec/controllers/facebook_feed_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe FacebookFeedController, :type => :controller do
 
-  let(:api_domain) { 'https://graph.facebook.com' }
+  let(:api_domain) { 'https://graph.facebook.com/v2.6' }
   let(:page_id) { "1234567890" }
   let(:api_path) { "posts" }
   let(:fields) { ["id", "from", "message", "picture", "link", "type", "created_time", "updated_time"] }


### PR DESCRIPTION
v2.0 of the facebook Graph API is deprecated and will be shut down first week of August. This just specifies that our requests are for the latest version of the API which is currently v2.6.