### PR TITLE
Gzip requests

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,8 @@ Bundler.require(*Rails.groups)
 
 module G5SocialFeedTrough
   class Application < Rails::Application
+
+    config.middleware.use Rack::Deflater
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Config change to gzip response bodies for things like static assets and json from the server to the browser. Until we get the form enhancer js moved into the CMS, this will also help with compressing that javascript when static web sites pull it in.

https://www.pivotaltracker.com/story/show/122241177
https://robots.thoughtbot.com/content-compression-with-rack-deflater