### PR TITLE
longer cache so we dont spill over api quota

### DIFF
--- a/app/controllers/google_plus_feed_controller.rb
+++ b/app/controllers/google_plus_feed_controller.rb
@@ -1,5 +1,5 @@
 class GooglePlusFeedController < ApplicationController
-  caches_action :show, expires_in: 1.hour
+  caches_action :show, expires_in: 2.hours
   
   def show
     GooglePlus.api_key=ENV['GOOGLE_PLUS_API_KEY']


### PR DESCRIPTION
we spilled over our google+ api quota last night about 8pm. So, this double's the time we cache those requests, which should theoretically cut our api hits in half.